### PR TITLE
Allow forms using PUT

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -45,7 +45,6 @@
 package mux
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 )
@@ -127,7 +126,6 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	method := req.Method
 
 	// fix for forms with given _method value
-	fmt.Println(w, req.FormValue("_method"))
 	if formMethod := req.FormValue("_method"); formMethod != "" {
 		method = strings.ToUpper(formMethod)
 	}

--- a/mux.go
+++ b/mux.go
@@ -44,7 +44,11 @@
 //  /foo            doesn't match
 package mux
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
 
 // Router is a http.Handler used to dispatch request to different handler
 // functions with routes.
@@ -121,6 +125,12 @@ func (r *Router) add(method string, path string, h http.HandlerFunc) {
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	path := req.URL.Path
 	method := req.Method
+
+	// fix for forms with given _method value
+	fmt.Println(w, req.FormValue("_method"))
+	if formMethod := req.FormValue("_method"); formMethod != "" {
+		method = strings.ToUpper(formMethod)
+	}
 
 	if h, ok := r.routes[method+path]; ok {
 		h.ServeHTTP(w, req)

--- a/mux.go
+++ b/mux.go
@@ -126,8 +126,10 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	method := req.Method
 
 	// fix for forms with given _method value
-	if formMethod := req.FormValue("_method"); formMethod != "" {
-		method = strings.ToUpper(formMethod)
+	if method == http.MethodPost {
+		if formMethod := req.FormValue("_method"); formMethod != "" {
+			method = strings.ToUpper(formMethod)
+		}
 	}
 
 	if h, ok := r.routes[method+path]; ok {

--- a/mux_test.go
+++ b/mux_test.go
@@ -160,6 +160,22 @@ func TestMethodNotAllowedDisabled(t *testing.T) {
 	}
 }
 
+func TestFormMethodFix(t *testing.T) {
+	m := New()
+	m.Get("/foo", func(w http.ResponseWriter, r *http.Request) {})
+	m.Put("/foo", func(w http.ResponseWriter, r *http.Request) {})
+
+	res := httptest.NewRecorder()
+	m.ServeHTTP(res, newRequest(
+		"POST",
+		"/foo",
+		strings.NewReader("<form method=post><input name=_method value=put></form>"),
+	))
+	if res.Code != http.StatusOK {
+		t.Errorf("for path %q: got code %d; want %d", "/bar", res.Code, http.StatusOK)
+	}
+}
+
 func newRequest(method string, path string, body io.Reader) *http.Request {
 	req, err := http.NewRequest(method, path, body)
 	if err != nil {


### PR DESCRIPTION
Allows forms to submit as other methods than "POST" or "GET" using the "_method" parameter.